### PR TITLE
Avoid sudo gpg

### DIFF
--- a/lib/setup-docker.js
+++ b/lib/setup-docker.js
@@ -287,7 +287,7 @@ system_profiler SPHardwareDataType || true
 
     core.debug('add apt-key');
     await shell(`
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor | sudo cat >/usr/share/keyrings/docker-archive-keyring.gpg
     `);
 
     message = 'add apt source';


### PR DESCRIPTION
Fixes failure with `gpg: WARNING: unsafe ownership on homedir '/home/user/.gnupg'` on ubuntu-18.04 runner